### PR TITLE
fix(release.yaml): update version extraction in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,12 @@ jobs:
       - name: update version
         shell: bash
         run: |
+          # get the version from the tag
           VERSION=$(echo $GITHUB_REF | sed 's/refs\/tags\/v//')
-          jq '.version = $VERSION' package.json > package.json.tmp
+          # remove the v prefix
+          VERSION=$(echo $VERSION | sed 's/v//')
+          # update the version in package.json
+          jq ".version = \"$VERSION\"" package.json > package.json.tmp
           mv package.json.tmp package.json
       - run: npm publish
         env:


### PR DESCRIPTION
This commit modifies the release workflow to correctly extract the version from the tag and update it in package.json. The version is now stripped of the 'v' prefix before being set in package.json.