### PR TITLE
Requiring `oxc-transform` as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ A Bun plugin for generating isolated declaration files (.d.ts) from TypeScript s
 
 ## Installation
 
+Install the plugin and its peer dependencies:
+
 ```bash
-bun add -d bun-plugin-isolated-decl
+bun add -d bun-plugin-isolated-decl typescript oxc-transform
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"format": "npm run lint -- --fix"
 	},
 	"peerDependencies": {
-		"typescript": "^5.5.3"
+		"typescript": "^5.5.3",
+		"oxc-transform": "^0.16.3"
 	},
 	"devDependencies": {
 		"@ryoppippi/eslint-config": "npm:@jsr/ryoppippi__eslint-config",


### PR DESCRIPTION
Fixes #12 