### PR TITLE
feat(tests): update build test to clean up before run

### DIFF
--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -1,10 +1,13 @@
 import path from 'node:path';
+import { $ } from 'bun';
 import { expect, test } from 'bun:test';
 import dts from '../index.ts';
 
 test('build', async () => {
 	const input = path.resolve(__dirname, 'fixtures/main.ts');
 	const dist = path.resolve(__dirname, 'out');
+
+	await $`rm -rf ${dist}`;
 
 	await Bun.build({
 		entrypoints: [input],
@@ -15,6 +18,6 @@ test('build', async () => {
 		external: ['*'],
 	});
 
-	const outputDts = await Bun.file(path.resolve(dist, 'main.d.ts')).text();
+	const outputDts = await $`cat ${path.resolve(dist, 'main.d.ts')}`.text();
 	expect(outputDts).toMatchSnapshot();
 });


### PR DESCRIPTION
This commit modifies the build test in `build.test.ts` to ensure that
the output directory is cleaned up before each run. This is achieved
by adding a `rm -rf ${dist}` command before the build process.

Additionally, the method of reading the output file has been changed
from using `Bun.file().text()` to using a shell command `cat`. This
change is intended to improve the reliability of the test.
