### PR TITLE
 Requiring is-glob as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
 		"prepare": "nlx bunpare"
 	},
 	"peerDependencies": {
+		"is-glob": "^4.0.3",
 		"oxc-transform": "^0.30.0",
 		"typescript": "^5.6.2"
 	},
 	"dependencies": {
+		"is-glob": "^4.0.3",
 		"oxc-transform": "^0.30.0",
 		"unplugin-isolated-decl": "^0.4.7"
 	},
@@ -45,6 +47,5 @@
 		"@types/bun": "latest",
 		"eslint": "^9.11.0",
 		"eslint-plugin-format": "^0.1.2",
-		"is-glob": "^4.0.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
 		"prepare": "nlx bunpare"
 	},
 	"peerDependencies": {
-		"is-glob": "^4.0.3",
-		"oxc-transform": "^0.30.0",
 		"typescript": "^5.6.2"
 	},
 	"dependencies": {


### PR DESCRIPTION
Fixes #57 

Note that I removed peerDeps as they are already in dep  section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies in the project configuration.
	- Added new dependency: `"is-glob": "^4.0.3"`.
	- Removed `"oxc-transform"` from peer dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->