### PR TITLE
feat: Add outdir to options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ type Entry = {
 type Options = {
 	/** generate declaration files even though there are errors */
 	forceGenerate?: boolean;
+    outdir?: string;
 };
 
 function isolatedDecl(options: Options = {}): BunPlugin {
@@ -31,7 +32,7 @@ function isolatedDecl(options: Options = {}): BunPlugin {
 		async setup(build): Promise<void> {
 			const entrypoints = [...build.config.entrypoints].sort();
 			const entriies: Entry[] = [];
-			const outdir = build.config?.outdir ?? './out';
+			const outdir = options.outdir ? options.outdir : build.config?.outdir ?? './out';
 			const resolvedOptions = {
 				forceGenerate: false,
 				...options,

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { type BunPlugin, Glob } from 'bun';
 // @ts-expect-error no type
@@ -77,8 +77,10 @@ function isolatedDecl(options: Options = {}): BunPlugin {
 				}
 				const root = build.config?.root ?? '';
 				const dtsID = path.relative(root, id.replace(/^.*\s/, '').replace(/\.[jtm]s$/, '.d.ts'));
-				const _path = path.join(outdir, dtsID);
-				await writeFile(_path, code, { flag: 'w' });
+				const _savepath = path.resolve(outdir, dtsID);
+				const _dirpath = path.dirname(_savepath);
+				await mkdir(_dirpath, { recursive: true });
+				await writeFile(_savepath, code);
 			}
 		},
 	};

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,8 @@ function isolatedDecl(options: Options = {}): BunPlugin {
 		async setup(build): Promise<void> {
 			const entrypoints = [...build.config.entrypoints].sort();
 			const entriies: Entry[] = [];
-			const outdir = (options.outdir != null) ? options.outdir : build.config?.outdir ?? './out';
+			const _basedir = build.config?.outdir ?? './out';
+			const outdir = (options.outdir != null) ? path.join(_basedir, options.outdir) : _basedir;
 			const resolvedOptions = {
 				forceGenerate: false,
 				...options,
@@ -76,7 +77,9 @@ function isolatedDecl(options: Options = {}): BunPlugin {
 					}
 				}
 				const root = build.config?.root ?? '';
-				const dtsID = path.relative(root, id.replace(/^.*\s/, '').replace(/\.[jtm]s$/, '.d.ts'));
+				const dtsID = (root.length > 0)
+					? path.relative(root, id).replace(/\.[jtm]s$/, '.d.ts')
+					: path.basename(id).replace(/\.[jtm]s$/, '.d.ts');
 				const _savepath = path.resolve(outdir, dtsID);
 				const _dirpath = path.dirname(_savepath);
 				await mkdir(_dirpath, { recursive: true });

--- a/tests/__snapshots__/build.test.ts.snap
+++ b/tests/__snapshots__/build.test.ts.snap
@@ -11,3 +11,51 @@ exports[`build with glob path 1`] = `
 export declare function hello(s: Str): Str;
 "
 `;
+
+exports[`build(set root option) 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;
+
+exports[`build (sublayer) 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;
+
+exports[`build set outdir 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;
+
+exports[`build single entrypoint 1`] = `
+"export type Str = string;
+export declare function hello(s: Str): Str;
+"
+`;
+
+exports[`build with glob entrypoints 1`] = `
+"export type Str = string;
+export declare function hello(s: Str): Str;
+"
+`;
+
+exports[`build nested entrypoint 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;
+
+exports[`build with custom outdir 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;
+
+exports[`build with custom outdir and root 1`] = `
+"export type Num = number;
+export declare function add(a: number, b: number): number;
+"
+`;

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -1,13 +1,15 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
-import { $, Glob } from 'bun';
+import { Glob } from 'bun';
 import { expect, test } from 'bun:test';
 import dts from '../index.ts';
 
-test('build', async () => {
-	const input = path.resolve(__dirname, 'fixtures/main.ts');
-	const dist = path.resolve(__dirname, 'out');
+const dist = path.resolve(__dirname, 'out');
 
-	await $`rm -rf ${dist}`;
+test('build single entrypoint', async () => {
+	const input = path.resolve(__dirname, 'fixtures/main.ts');
+
+	await fs.rm(dist, { recursive: true, force: true });
 
 	await Bun.build({
 		entrypoints: [input],
@@ -18,21 +20,18 @@ test('build', async () => {
 		external: ['*'],
 	});
 
-	const outputDts = await $`cat ${path.resolve(dist, 'main.d.ts')}`.text();
+	const outputDts = await fs.readFile(path.resolve(dist, 'main.d.ts'), 'utf-8');
 	expect(outputDts).toMatchSnapshot();
 });
 
-test('build with glob path', async () => {
-	// const input = path.resolve(__dirname, 'fixtures/*.ts');
-	const dist = path.resolve(__dirname, 'out');
-
-	const entrypoints = [];
+test('build with glob entrypoints', async () => {
 	const glob = new Glob(path.resolve(__dirname, 'fixtures/*.ts'));
+	const entrypoints = [];
 	for await (const file of glob.scan('.')) {
 		entrypoints.push(file);
 	}
 
-	await $`rm -rf ${dist}`;
+	await fs.rm(dist, { recursive: true, force: true });
 
 	await Bun.build({
 		entrypoints,
@@ -43,6 +42,61 @@ test('build with glob path', async () => {
 		external: ['*'],
 	});
 
-	const outputDts = await $`cat ${path.resolve(dist, 'main.d.ts')}`.text();
+	const outputDts = await fs.readFile(path.resolve(dist, 'main.d.ts'), 'utf-8');
+	expect(outputDts).toMatchSnapshot();
+});
+
+test('build nested entrypoint', async () => {
+	const input = path.resolve(__dirname, 'fixtures/folder/child.ts');
+
+	await fs.rm(dist, { recursive: true, force: true });
+
+	await Bun.build({
+		entrypoints: [input],
+		outdir: dist,
+		minify: false,
+		plugins: [dts()],
+		target: 'bun',
+		external: ['*'],
+	});
+
+	const outputDts = await fs.readFile(path.resolve(dist, 'child.d.ts'), 'utf-8');
+	expect(outputDts).toMatchSnapshot();
+});
+
+test('build with custom outdir', async () => {
+	const input = path.resolve(__dirname, 'fixtures/folder/child.ts');
+
+	await fs.rm(dist, { recursive: true, force: true });
+
+	await Bun.build({
+		entrypoints: [input],
+		outdir: dist,
+		minify: false,
+		plugins: [dts({ outdir: 'dts' })],
+		target: 'bun',
+		external: ['*'],
+	});
+
+	const outputDts = await fs.readFile(path.resolve(dist, 'dts', 'child.d.ts'), 'utf-8');
+	expect(outputDts).toMatchSnapshot();
+});
+
+test('build with custom outdir and root', async () => {
+	const input = path.resolve(__dirname, 'fixtures/folder/child.ts');
+
+	await fs.rm(dist, { recursive: true, force: true });
+
+	await Bun.build({
+		entrypoints: [input],
+		outdir: dist,
+		minify: false,
+		plugins: [dts({ outdir: 'dts' })],
+		target: 'bun',
+		root: 'tests/fixtures',
+		external: ['*'],
+	});
+
+	const outputDts = await fs.readFile(path.resolve(dist, 'dts', 'folder', 'child.d.ts'), 'utf-8');
 	expect(outputDts).toMatchSnapshot();
 });

--- a/tests/fixtures/folder/child.ts
+++ b/tests/fixtures/folder/child.ts
@@ -1,0 +1,5 @@
+export type Num = number;
+
+export function add(a: number, b: number): number {
+	return a + b;
+}


### PR DESCRIPTION
使用するときに`build.config.outdir`で指定した場所とは別の場所に
d.tsを生成したかったため`outdir`を指定できるようにしたい。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional setting allowing users to specify a custom output directory for generated files. The system now prioritizes the user-defined setting and falls back to sensible defaults, enhancing overall configuration flexibility.
  - Added basic arithmetic functionality with a new `add` function and a type alias `Num`.
  
- **Bug Fixes**
  - Updated file writing mechanism to use Node.js file system operations, improving reliability and performance.

- **Tests**
  - Enhanced the test suite with new cases for building TypeScript files, including scenarios for custom output directories and nested entrypoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->